### PR TITLE
Initial Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bower_components
+

--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
+# iron-scroll-target-behavior
 
-<!---
+`Polymer.IronScrollTargetBehavior` allows an element to respond to scroll events from a designated scroll target.
 
-This README is automatically generated from the comments in these files:
-
-
-Edit those files, and our readme bot will duplicate them over here!
-Edit this file, and the bot will squash your changes :)
-
-The bot does some handling of markdown. Please file a bug if it does the wrong
-thing! https://github.com/PolymerLabs/tedium/issues
-
--->
-
-_[Demo and API Docs](https://elements.polymer-project.org/elements/iron-scroll-target-behavior)_
-
+Elements that consume this behavior can override the `_scrollHandler` method to add logic on the scroll event.

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "iron-scroll-target-behavior",
+  "version": "1.0.0",
+  "description": "Allows to define a scroller target",
+  "private": true,
+  "license": "http://polymer.github.io/LICENSE.txt",
+  "main": [
+    "iron-scroll-target.html"
+  ],
+  "authors": [
+    "The Polymer Authors"
+  ],
+  "keywords": [
+    "web-components",
+    "polymer",
+    "scroll"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/PolymerElements/iron-scroll-target-behavior.git"
+  },
+  "homepage": "https://github.com/PolymerElements/iron-scroll-target-behavior",
+  "ignore": [],
+  "dependencies": {
+    "polymer": "Polymer/polymer#^1.0.0"
+  },
+  "devDependencies": {
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+  }
+}

--- a/demo/document.html
+++ b/demo/document.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<!--
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html id="html">
+  <head>
+
+    <title>iron-scroll-target-behavior using the document scroll</title>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <link rel="import" href="../iron-scroll-target-behavior.html">
+    <link rel="import" href="x-scrollable.html">
+
+    <style>
+
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+    </style>
+  </head>
+  <body unresolved>
+
+    <x-scrollable scroll-target="html"></x-scrollable>
+
+  </body>
+</html>

--- a/demo/scrolling-region.html
+++ b/demo/scrolling-region.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!--
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+  <head>
+
+    <title>iron-scroll-target-behavior using a scrolling region</title>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <link rel="import" href="../iron-scroll-target-behavior.html">
+    <link rel="import" href="x-scrollable.html">
+
+    <style>
+
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      #region {
+        height: 50vh;
+        overflow: auto;
+        position: absolute;
+        top: 25vh;
+        left: 25vh;
+        right: 25vh;
+        box-shadow: 0 0 60px rgba(0,0,0,0.5);
+      }
+
+    </style>
+  </head>
+  <body unresolved>
+    
+    <div id="region">
+      <x-scrollable scroll-target="region"></x-scrollable>
+    </div>
+
+  </body>
+</html>

--- a/demo/x-scrollable.html
+++ b/demo/x-scrollable.html
@@ -1,0 +1,100 @@
+<!--
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../iron-scroll-target-behavior.html">
+
+<dom-module id="x-scrollable">
+
+  <style>
+
+    :host {
+      display: block;
+      font: 14px arial;
+    }
+
+    .scrollState {
+      border-left: 1px solid #ccc;
+      border-right: 1px solid #ccc;
+      border-bottom: 1px solid #ccc;
+      font-weight: bold;
+      background-color: #eee;
+      position: fixed;
+      top: 0;
+      left: calc(50% - 100px);
+      padding: 10px;
+      width: 220px;
+      text-align: center;
+    }
+
+    .item {
+      border-bottom: 1px solid #ccc;
+      background-color: white;
+      padding: 20px;
+      width: 200%;
+    }
+
+  </style>
+
+  <template>
+
+    <div class="scrollState">scrollTop: [[xScrollTop]] - scrollLeft: [[xScrollLeft]]</div>
+
+    <template is="dom-repeat" items="[[_getItems(itemCount)]]">
+      <div class="item">[[index]]</div>
+    </template>
+
+  </template>
+
+</dom-module>
+
+<script>
+  Polymer({
+
+    is: 'x-scrollable',
+
+    properties: {
+
+      xScrollTop: {
+        type: Number,
+        readOnly: true,
+        value: 0
+      },
+
+      xScrollLeft: {
+        type: Number,
+        readOnly: true,
+        value: 0
+      },
+
+      itemCount: {
+        type: Number,
+        value: 200
+      }
+
+    },
+
+    behaviors: [
+      Polymer.IronScrollTargetBehavior
+    ],
+
+    _scrollHandler: function() {
+      this._setXScrollTop(this._scrollTop);
+      this._setXScrollLeft(this._scrollLeft);
+    },
+
+    _getItems: function(itemCount) {
+      var items = new Array(itemCount);
+      while (itemCount > 0) {
+        items[--itemCount] = true;
+      }
+      return items;
+    }
+  });
+</script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+<head>
+
+  <title>iron-scroll-target-behavior</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
+
+</head>
+<body>
+
+  <iron-component-page></iron-component-page>
+
+</body>
+</html>

--- a/iron-scroll-target-behavior.html
+++ b/iron-scroll-target-behavior.html
@@ -1,0 +1,225 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+
+<script>
+/**
+ * `Polymer.IronScrollTargetBehavior` allows an element to respond to scroll events from a
+ * designated scroll target.
+ *
+ * Elements that consume this behavior can override the `_scrollHandler`
+ * method to add logic on the scroll event.
+ *
+ * @polymerBehavior
+ * @demo demo/scrolling-region.html Scrolling Region
+ * @demo demo/document.html Document Element
+ */
+
+  Polymer.IronScrollTargetBehavior = {
+
+    properties: {
+
+      /**
+       * Specifies the element that will handle the scroll event
+       * on the behalf of the current element. This is typically a reference to an `Element`,
+       * but there are a few more posibilities:
+       *
+       * ### Elements id
+       *
+       *```html
+       * <div id="scrollable-element" style="overflow-y: auto;">
+       *  <x-element scroll-target="scrollable-element">
+       *    Content
+       *  </x-element>
+       * </div>
+       *```
+       * In this case, `scrollTarget` will point to the outer div element. Alternatively,
+       * you can set the property programatically:
+       *
+       *```js
+       * appHeader.scrollTarget = document.querySelector('#scrollable-element');
+       *```
+       */
+      scrollTarget: {
+        type: HTMLElement,
+        value: function() {
+          return this._defaultScrollTarget;
+        }
+      }
+    },
+
+    observers: [
+      '_scrollTargetChanged(scrollTarget, isAttached)'
+    ],
+
+    _scrollTargetChanged: function(scrollTarget, isAttached) {
+      // Remove lister to the current scroll target
+      if (this._oldScrollTarget) {
+        if (this._oldScrollTarget === this._doc) {
+          window.removeEventListener('scroll', this._boundScrollHandler);
+        } else if (this._oldScrollTarget.removeEventListener) {
+          this._oldScrollTarget.removeEventListener('scroll', this._boundScrollHandler);
+        }
+        this._oldScrollTarget = null;
+      }
+      if (isAttached) {
+        // Support element id references
+        if (typeof scrollTarget === 'string') {
+
+          var ownerRoot = Polymer.dom(this).getOwnerRoot();
+          this.scrollTarget = (ownerRoot && ownerRoot.$) ?
+              ownerRoot.$[scrollTarget] : Polymer.dom(this.ownerDocument).querySelector('#' + scrollTarget);
+
+        } else if (this._scrollHandler) {
+
+          this._boundScrollHandler = this._boundScrollHandler || this._scrollHandler.bind(this);
+          // Add a new listener
+          if (scrollTarget === this._doc) {
+            window.addEventListener('scroll', this._boundScrollHandler);
+            if (this._scrollTop !== 0 || this._scrollLeft !== 0) {
+              this._scrollHandler();
+            }
+          } else if (scrollTarget && scrollTarget.addEventListener) {
+            scrollTarget.addEventListener('scroll', this._boundScrollHandler);
+          }
+          this._oldScrollTarget = scrollTarget;
+        }
+      }
+    },
+
+    /**
+     * Runs on every scroll event. Consumer of this behavior may want to override this method.
+     *
+     * @protected
+     * @abstract
+     */
+    _scrollHandler: function scrollHandler() {},
+
+    /**
+     * The default scroll target. Consumers of this behavior may want to customize
+     * the default scroll target.
+     *
+     * @type {Element}
+     */
+    get _defaultScrollTarget() {
+      return this._doc;
+    },
+
+    /**
+     * Shortcut for the document element
+     *
+     * @type {Element}
+     */
+    get _doc() {
+      return this.ownerDocument.documentElement;
+    },
+
+    /**
+     * Gets the number of pixels that the content of an element is scrolled upward.
+     *
+     * @type {number}
+     */
+    get _scrollTop() {
+      if (this._isValidScrollTarget()) {
+        return this.scrollTarget === this._doc ? window.pageYOffset : this.scrollTarget.scrollTop;
+      }
+      return 0;
+    },
+
+    /**
+     * Gets the number of pixels that the content of an element is scrolled to the left.
+     *
+     * @type {number}
+     */
+    get _scrollLeft() {
+      if (this._isValidScrollTarget()) {
+        return this.scrollTarget === this._doc ? window.pageXOffset : this.scrollTarget.scrollLeft;
+      }
+      return 0;
+    },
+
+    /**
+     * Sets the number of pixels that the content of an element is scrolled upward.
+     *
+     * @type {number}
+     */
+    set _scrollTop(top) {
+      if (this.scrollTarget === this._doc) {
+        window.scrollTo(window.pageXOffset, top);
+      } else if (this._isValidScrollTarget()) {
+        this.scrollTarget.scrollTop = top;
+      }
+    },
+
+    /**
+     * Sets the number of pixels that the content of an element is scrolled to the left.
+     *
+     * @type {number}
+     */
+    set _scrollLeft(left) {
+      if (this.scrollTarget === this._doc) {
+        window.scrollTo(left, window.pageYOffset);
+      } else if (this._isValidScrollTarget()) {
+        this.scrollTarget.scrollLeft = left;
+      }
+    },
+
+    /**
+     * Scrolls the content to a particular place.
+     *
+     * @method scroll
+     * @param {number} top The top position
+     * @param {number} left The left position
+     */
+    scroll: function(top, left) {
+       if (this.scrollTarget === this._doc) {
+        window.scrollTo(top, left);
+      } else if (this._isValidScrollTarget()) {
+        this.scrollTarget.scrollTop = top;
+        this.scrollTarget.scrollLeft = left;
+      }
+    },
+
+    /**
+     * Gets the width of the scroll target.
+     *
+     * @type {number}
+     */
+    get _scrollTargetWidth() {
+      if (this._isValidScrollTarget()) {
+        return this.scrollTarget === this._doc ? window.innerWidth : this.scrollTarget.offsetWidth;
+      }
+      return 0;
+    },
+
+    /**
+     * Gets the height of the scroll target.
+     *
+     * @type {number}
+     */
+    get _scrollTargetHeight() {
+      if (this._isValidScrollTarget()) {
+        return this.scrollTarget === this._doc ? window.innerHeight : this.scrollTarget.offsetHeight;
+      }
+      return 0;t
+    },
+
+    /**
+     * Returns true if the scroll target is a valid HTMLElement.
+     *
+     * @return {boolean}
+     */
+    _isValidScrollTarget: function() {
+      return this.scrollTarget instanceof HTMLElement;
+    }
+  };
+
+</script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html id="html">
+<head>
+  <meta charset="UTF-8">
+  <title>iron-scroll-target-behavior test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="x-scrollable.html">
+
+  <style>
+    #temporaryScrollingRegion,
+    #region {
+      overflow: auto;
+      width: 100px;
+      height: 100px;
+    }
+  </style>
+</head>
+<body>
+
+  <test-fixture id="trivialScrollable">
+    <template>
+      <div id="temporaryScrollingRegion">
+        <x-scrollable></x-scrollable>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="trivialScrollingRegion">
+    <template>
+      <div id="region">
+        <x-scrollable scroll-target="region"></x-scrollable>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="trivialDocumentScroll">
+    <template>
+      <x-scrollable scroll-target="html"></x-scrollable>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    suite('basic features', function() {
+      var scrollingRegion, xScroll;
+
+      setup(function() {
+        scrollingRegion = fixture('trivialScrollable');
+        xScroll = Polymer.dom(scrollingRegion).querySelector('x-scrollable');
+      });
+
+      test('default', function() {
+        assert.equal(xScroll._scrollTop, 0, '_scrollTop');
+        assert.equal(xScroll._scrollLeft, 0, '_scrollLeft');
+        assert.equal(xScroll._scrollTargetWidth, 0, '_scrollTargetWidth');
+        assert.equal(xScroll._scrollTargetHeight, 0, '_scrollTargetHeight');
+        assert.equal(xScroll.scrollTarget, null, 'scrollTarget');
+        assert.equal(xScroll._defaultScrollTarget, xScroll.scrollTarget, '_defaultScrollTarget');
+      });
+
+      test('invalid `scrollTarget` selector', function(done) {
+        flush(function() {
+          xScroll.scrollTarget = 'invalid-id';
+          assert.equal(xScroll.scrollTarget, null);
+          done();
+        });
+      });
+
+      test('valid `scrollTarget` selector', function(done) {
+        flush(function() {
+          xScroll.scrollTarget = 'temporaryScrollingRegion';
+          assert.equal(xScroll.scrollTarget, scrollingRegion);
+          done();
+        });
+      });
+    });
+
+    suite('scrolling region', function() {
+      var scrollingRegion, xScrollable;
+
+      setup(function() {
+        scrollingRegion = fixture('trivialScrollingRegion');
+        xScrollable = Polymer.dom(scrollingRegion).querySelector('x-scrollable');
+      });
+
+      teardown(function() {
+        xScrollable._scrollTop = 0;
+        xScrollable._scrollLeft = 0;
+      });
+
+      test('scrollTarget reference', function(done) {
+        flush(function() {
+          assert.equal(xScrollable.scrollTarget, scrollingRegion);
+          done();
+        });
+      });
+
+      test('invalid scrollTarget', function(done) {
+        flush(function() {
+          assert.equal(xScrollable.scrollTarget, scrollingRegion);
+          done();
+        });
+      });
+
+      test('setters', function(done) {
+        flush(function() {
+          xScrollable._scrollTop = 100;
+          xScrollable._scrollLeft = 100;
+
+          assert.equal(scrollingRegion.scrollTop, 100);
+          assert.equal(scrollingRegion.scrollLeft, 100);
+
+          done();
+        });
+      });
+
+      test('getters', function(done) {
+        flush(function() {
+          scrollingRegion.scrollTop = 50;
+          scrollingRegion.scrollLeft = 50;
+
+          assert.equal(xScrollable._scrollTop, 50, '_scrollTop');
+          assert.equal(xScrollable._scrollLeft, 50, '_scrollLeft');
+          assert.equal(xScrollable._scrollTargetWidth, scrollingRegion.offsetWidth, '_scrollTargetWidth');
+          assert.equal(xScrollable._scrollTargetHeight, scrollingRegion.offsetHeight, '_scrollTargetHeight');
+
+          done();
+        });
+      });
+
+      test('scroll method', function(done) {
+        flush(function() {
+          xScrollable.scroll(110, 110);
+
+          assert.equal(xScrollable._scrollTop, 110);
+          assert.equal(xScrollable._scrollLeft, 110);
+
+          xScrollable.scroll(0, 0);
+
+          assert.equal(xScrollable._scrollTop, 0);
+          assert.equal(xScrollable._scrollLeft, 0);
+
+          done();
+        });
+      });
+    });
+
+    suite('document scroll', function() {
+      var xScrollable;
+
+      setup(function() {
+        xScrollable = fixture('trivialDocumentScroll');
+      });
+
+      teardown(function() {
+        xScrollable._scrollTop = 0;
+        xScrollable._scrollLeft = 0;
+      });
+
+      test('scrollTarget reference', function(done) {
+        flush(function() {
+          assert.equal(xScrollable.scrollTarget, document.documentElement);
+          done();
+        });
+      });
+
+      test('setters', function(done) {
+        flush(function() {
+          xScrollable._scrollTop = 100;
+          xScrollable._scrollLeft = 100;
+
+          assert.equal(window.pageXOffset, 100);
+          assert.equal(window.pageYOffset, 100);
+
+          done();
+        });
+      });
+
+      test('getters', function(done) {
+        flush(function() {
+          window.scrollTo(50, 50);
+
+          assert.equal(xScrollable._scrollTop, 50, '_scrollTop');
+          assert.equal(xScrollable._scrollLeft, 50, '_scrollLeft');
+          assert.equal(xScrollable._scrollTargetWidth, window.innerWidth, '_scrollTargetWidth');
+          assert.equal(xScrollable._scrollTargetHeight, window.innerHeight, '_scrollTargetHeight');
+
+          done();
+        });
+      });
+
+      test('scroll method', function(done) {
+        flush(function() {
+          xScrollable.scroll(110, 110);
+
+          assert.equal(xScrollable._scrollTop, 110);
+          assert.equal(xScrollable._scrollLeft, 110);
+
+          xScrollable.scroll(0, 0);
+
+          assert.equal(xScrollable._scrollTop, 0);
+          assert.equal(xScrollable._scrollLeft, 0);
+
+          done();
+        });
+      });
+    });
+
+  </script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<!--
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <title>Tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+
+</head>
+<body>
+
+  <script>
+
+    WCT.loadSuites([
+      'basic.html'
+    ]);
+
+  </script>
+
+</body>
+</html>

--- a/test/x-scrollable.html
+++ b/test/x-scrollable.html
@@ -1,0 +1,67 @@
+<!--
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../iron-scroll-target-behavior.html">
+
+<dom-module id="x-scrollable">
+
+  <style>
+
+    :host {
+      display: block;
+      font: 14px arial;
+    }
+
+    .item {
+      border-bottom: 1px solid #ccc;
+      background-color: white;
+      padding: 20px;
+      width: 200%;
+    }
+
+  </style>
+
+  <template>
+    <template is="dom-repeat" items="[[_getItems(itemCount)]]">
+      <div class="item">[[index]]</div>
+    </template>
+  </template>
+
+</dom-module>
+
+<script>
+  Polymer({
+
+    is: 'x-scrollable',
+
+    properties: {
+
+      itemCount: {
+        type: Number,
+        value: 200
+      }
+
+    },
+
+    behaviors: [
+      Polymer.IronScrollTargetBehavior
+    ],
+
+    _defaultScrollTarget: null,
+
+    _getItems: function(itemCount) {
+      var items = new Array(itemCount);
+      while (itemCount > 0) {
+        items[--itemCount] = true;
+      }
+      return items;
+    }
+  });
+</script>


### PR DESCRIPTION
This is the initial implementation of `IronScrollTargetBehavior` that will allow to customize the scroll target of iron-scroll-threshold and iron-list. I have implemented a very tiny element deference process by ids that follows the design document proposed by Chris.

This behavior exposes a public  property of type `Element` and provide a set of protected methods and properties:
## Sample use
- https://github.com/PolymerElements/iron-list/pull/175
- https://github.com/PolymerElements/iron-scroll-threshold/pull/1
- App layout will also replace the behavior it currently has to manage the scroll target following this new pattern. https://github.com/PolymerLabs/app-layout/blob/master/app-scroll-behaviors/app-custom-scroller-behavior.html
## API
### Public
- `scrollTarget` Polymer property that  specifies the element that will handle the scroll event. This property accepts an element reference or an id to an element in the current host.
- `scroll(top, left)`  Scrolls the content to a particular place.
### Protected
- `_scrollHandler()` The method that is called on every scroll event.
- `_defaultScrollTarget`  iron-list may add logic here to detect whether the scroll target should be set to itself or the a parent paper-scroll-header-panel.
- `_scrollTop`.  Gets/Sets the scrollTop property on the designed scrollTarget.
- `_scrollLeft` Gets/Sets the scrollLeft property on the designed scrollTarget.
- `_scrollTargetWidth`.  Gets the scroll target width.
- `_scrollTargetHeight` Gets the scroll target height.
## Open question

``` html
<html id="html">
```

Is this the final way?  It would make a lot of sense to have a few reserved words. e.g. `html` or `document`, that way we won't need to add the `id` to the document element.

cc @kevinpschaaf 
