### PR TITLE
A couple of small fixes for the compiler

### DIFF
--- a/iron-scroll-target-behavior.html
+++ b/iron-scroll-target-behavior.html
@@ -47,6 +47,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *```js
        * appHeader.scrollTarget = document.querySelector('#scrollable-element');
        *```
+       * 
+       * @type {HTMLElement}
        */
       scrollTarget: {
         type: HTMLElement,
@@ -99,7 +101,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Runs on every scroll event. Consumer of this behavior may want to override this method.
      *
      * @protected
-     * @abstract
      */
     _scrollHandler: function scrollHandler() {},
 
@@ -209,7 +210,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this._isValidScrollTarget()) {
         return this.scrollTarget === this._doc ? window.innerHeight : this.scrollTarget.offsetHeight;
       }
-      return 0;t
+      return 0;
     },
 
     /**


### PR DESCRIPTION
@abstract is an unknown jsdoc tag, the compiler doesn't understand `type: HTMLElement`, and there was a typo that had no runtime effect but looked suspicious `return 0;t` rather than `return 0;`
