### PR TITLE
doc(iron-scroll-target-behavior): default for scrollTarget

### DIFF
--- a/iron-scroll-target-behavior.html
+++ b/iron-scroll-target-behavior.html
@@ -60,6 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *```
        *
        * @type {Element}
+       * @default document
        */
       scrollTarget: {
         type: Object,


### PR DESCRIPTION
I force to check the code for find default value for `scrollTarget`