### PR TITLE
Accept an options object in `scroll` method

### DIFF
--- a/iron-scroll-target-behavior.d.ts
+++ b/iron-scroll-target-behavior.d.ts
@@ -101,10 +101,10 @@ declare namespace Polymer {
     /**
      * Scrolls the content to a particular place.
      *
-     * @param left The left position
+     * @param leftOrOptions The left position or scroll options
      * @param top The top position
      */
-    scroll(left: number, top: number): void;
+    scroll(leftOrOptions: number|ScrollToOptions, top?: number): void;
 
     /**
      * Returns true if the scroll target is a valid HTMLElement.

--- a/iron-scroll-target-behavior.html
+++ b/iron-scroll-target-behavior.html
@@ -189,15 +189,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Scrolls the content to a particular place.
      *
      * @method scroll
-     * @param {number} left The left position
+     * @param {number|ScrollToOptions} leftOrOptions The left position or scroll options
      * @param {number} top The top position
      */
-    scroll: function(left, top) {
-       if (this.scrollTarget === this._doc) {
-        window.scrollTo(left, top);
+    scroll: function(leftOrOptions, top) {
+      var opts = leftOrOptions;
+      if (typeof leftOrOptions !== 'object') {
+        opts = { x: leftOrOptions, y: top };
+      }
+
+      if (this.scrollTarget === this._doc) {
+        window.scrollTo(opts.x, opts.y);
       } else if (this._isValidScrollTarget()) {
-        this.scrollTarget.scrollLeft = left;
-        this.scrollTarget.scrollTop = top;
+        this.scrollTarget.scrollLeft = opts.x;
+        this.scrollTarget.scrollTop = opts.y;
       }
     },
 

--- a/iron-scroll-target-behavior.html
+++ b/iron-scroll-target-behavior.html
@@ -189,8 +189,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * Scrolls the content to a particular place.
      *
      * @method scroll
-     * @param {number|ScrollToOptions} leftOrOptions The left position or scroll options
-     * @param {number} top The top position
+     * @param {number|!ScrollToOptions} leftOrOptions The left position or scroll options
+     * @param {number=} top The top position
+     * @return {void}
      */
     scroll: function(leftOrOptions, top) {
       var opts = leftOrOptions;

--- a/iron-scroll-target-behavior.html
+++ b/iron-scroll-target-behavior.html
@@ -194,16 +194,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @return {void}
      */
     scroll: function(leftOrOptions, top) {
-      var opts = leftOrOptions;
-      if (typeof leftOrOptions !== 'object') {
-        opts = { x: leftOrOptions, y: top };
+      var left = leftOrOptions;
+
+      if (typeof leftOrOptions === 'object') {
+        left = leftOrOptions.x;
+        top = leftOrOptions.y;
       }
 
       if (this.scrollTarget === this._doc) {
-        window.scrollTo(opts.x, opts.y);
+        window.scrollTo(left, top);
       } else if (this._isValidScrollTarget()) {
-        this.scrollTarget.scrollLeft = opts.x;
-        this.scrollTarget.scrollTop = opts.y;
+        this.scrollTarget.scrollLeft = left;
+        this.scrollTarget.scrollTop = top;
       }
     },
 

--- a/iron-scroll-target-behavior.html
+++ b/iron-scroll-target-behavior.html
@@ -197,8 +197,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var left = leftOrOptions;
 
       if (typeof leftOrOptions === 'object') {
-        left = leftOrOptions.x;
-        top = leftOrOptions.y;
+        left = leftOrOptions.left;
+        top = leftOrOptions.top;
       }
 
       if (this.scrollTarget === this._doc) {


### PR DESCRIPTION
Part of polymer/gen-typescript-declarations#79.

An element mixing in this behaviour won't compile in TypeScript because our definition of the `scroll` method incorrectly overrides the base one that `Element` has.

To resolve this, i've added an options object to match the built in scroll method.

I also re-ran gen-tsd.

cc @aomarks 