### PR TITLE
Exclude scroll method from type generation.

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,5 @@
+{
+  "excludeIdentifiers": [
+    "scroll"
+  ]
+}


### PR DESCRIPTION
This method's implementation is compatible with the standard `Element` scroll method, but since we can't represent the overloading with a Closure type, TypeScript doesn't believe that they are compatible.

```ts
scroll(options?: ScrollToOptions): void
scroll(x: number, y: number): void;
```

Since it's already on the `Element` base class, the simplest thing to do here is just remove it from our typings, rather than trying to make the signatures line up.

Although, I'm not entirely sure if `Element.scroll` is a standard thing that *should* be in the TypeScript typings standard lib. It's not documented on MDN.