### PR TITLE
Enable compatibility when it hosted by a LitElement

### DIFF
--- a/iron-scroll-target-behavior.js
+++ b/iron-scroll-target-behavior.js
@@ -96,6 +96,8 @@ export const IronScrollTargetBehavior = {
 
       this.scrollTarget = domHost && domHost.$ ?
           domHost.$[scrollTarget] :
+          domHost.shadowRoot ?
+          domHost.shadowRoot.querySelector('#' + scrollTarget) :
           dom(this.ownerDocument).querySelector('#' + scrollTarget);
 
     } else if (this._isValidScrollTarget()) {


### PR DESCRIPTION
When the component is hosted by a LitElement the `domHost.$`doesn't exist so the `scrollTarget` is `null`.

It is a simple fix, we search in `domHost.shadowRoot` in case of `domHost.$` doesn't exist.